### PR TITLE
Arruma deploy somente quando houver merge

### DIFF
--- a/.github/workflows/service-deploy.yml
+++ b/.github/workflows/service-deploy.yml
@@ -1,11 +1,14 @@
 name: heroku-deploy
 on:
   pull_request:
+    types:
+      - closed
     branches:
       - main
 
 jobs:
   deploy-heroku:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: heroku deploy
     steps:


### PR DESCRIPTION
## Modificações

A action de deploy fazia o deploy toda vez que havia PR para a main.
Agora o comportamento é fazer deploy somente quando o PR for aceito na main.

## Tipo de modificações

- [x] _ ​​correção de bug_

## Lista de controle:
- [ ] Meu código segue a folha de estilos implementada
- [ ] Meu _commits_ segue a política de commits do repo.