### PR TITLE
executa sonar scan independente dos testes passarem

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,4 +1,4 @@
-name: analysis
+name: CodeAnalysis
 on:
   pull_request:
    branches:
@@ -18,11 +18,13 @@ jobs:
       - name: Test and coverage
         run: yarn test:all
       - name: SonarCloud Scan
+        if: ${{ always() }}
         uses: SonarSource/sonarcloud-github-action@master
         env:
           GITHUB_TOKEN: ${{secrets.GIT_TOKEN}}
           SONAR_TOKEN: ${{secrets.SONAR_TOKEN}}
   get_metrics:
+    if: always() && github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     needs: sonarcloud
     steps:


### PR DESCRIPTION
## Modificações
Muda o nome da action para ficar mais intuitivo.
Faz o scan do sonar independente dos testes passarem.
Faz o get_metrics toda vez que for feito o merge do PR.